### PR TITLE
Add catch for `Y||a` unit cell convention

### DIFF
--- a/damask_parse/utils.py
+++ b/damask_parse/utils.py
@@ -1521,8 +1521,9 @@ def get_volume_element_materials(volume_element, homog_schemes=None, phases=None
                     msg = 'Orientation `unit_cell_alignment` must be specified.'
                     raise ValueError(msg)
 
-                if volume_element['orientations']['unit_cell_alignment'].get('y') == 'b':
-                    # Convert from y//b to x//a:
+                if (volume_element['orientations']['unit_cell_alignment'].get('y') == 'b' and
+                    volume_element['orientations']['unit_cell_alignment'].get('y') == 'a'):
+                    # Convert from y//b or y//a to x//a or x//b:
                     hex_transform_quat = axang2quat(
                         volume_element['orientations']['P'] * np.array(
                             [0, 0, 1], dtype=np.longdouble),
@@ -1534,7 +1535,8 @@ def get_volume_element_materials(volume_element, homog_schemes=None, phases=None
                         P=volume_element['orientations']['P'],
                     )
 
-                elif volume_element['orientations']['unit_cell_alignment'].get('x') != 'a':
+                elif (volume_element['orientations']['unit_cell_alignment'].get('x') != 'a' and
+                      volume_element['orientations']['unit_cell_alignment'].get('x') != 'b'):
                     msg = (f'Cannot convert from the following specified unit cell '
                            f'alignment to DAMASK-compatible unit cell alignment (x//a): '
                            f'{volume_element["orientations"]["unit_cell_alignment"]}')


### PR DESCRIPTION
Following discussion about choice of HCP unit cell convention for some EBSD and SXRD texture data, @mikesmic has pointed out that the current logic on l1524 in damask-parse/utils.py is flawed, and does not correctly convert the unit cell convention of `X||b*, Y||a, Z||c*` to DAMASK's `X||a, Y||b*, Z||c` because it only checks if `['Y'] == b`, which is the HKL/Oxford HCP convention. However, equivalent to this is `['Y']==a` which needs to be accounted for in the logic. Please see the image below @mikesmic sketched up showing the equivalence of these conventions:
SXRD data was post-processed using the convention in **3.** `X||b*, Y||a, Z||c*.` This is equivalent to the HKL/Oxford Aztec HCP convention in **1.** `X||a_3*, Y||b, Z||c*` right?
Therefore if DAMASK_parse can catch that `Y||a` is also NOT the damask convention, it will transform it correctly for use in the model.
![HEW_unit_cells](https://user-images.githubusercontent.com/61540494/220088530-a8839c79-3cae-4448-b016-140dce08bb3e.png)
Any help on this matter would be greatly appreciated.
Guy